### PR TITLE
Patch for getEntityName function

### DIFF
--- a/system/core/constraint/AbstractConstraint.cfc
+++ b/system/core/constraint/AbstractConstraint.cfc
@@ -32,6 +32,8 @@ component accessors="true" {
 		if( structKeyExists(meta,"persistent") && meta.persistent ){
 			if(structKeyExists(meta,"entity")){
 				entity = meta.entity;
+			} else if(structKeyExists(meta,"entityName")){
+				entity = meta.entityName;
 			} else {
 				if(structKeyExists(meta,"fullname")){
 					entity = listLast(meta.fullname,".");


### PR DESCRIPTION
This small patch fixes an issue I was having where the "unique" constraint was throwing an exception. The root cause was that the getEntityName function was trying to guess the entity name from the fullname property. This doesn't work in cases where your CFC filename is capitalized differently from the actual entity name.

Example: Filename is 'user.cfc', but the component is defined with entityName="User", hyrule incorrectly guesses that the entity name is "user". 

This now tries to use the entityName property before falling back to fullname.
