### PR TITLE
Missing comma in ValidationMessageProvider

### DIFF
--- a/system/core/result/ValidationMessageProvider.cfc
+++ b/system/core/result/ValidationMessageProvider.cfc
@@ -53,7 +53,7 @@ component accessors="true" {
 		
 		// if you are here we couldn't find a message 
 		throw(
-			type="ValidationMessage"
+			type="ValidationMessage",
 			message="There is no message defined for type '#lcase(type)#'"
 		);
 		


### PR DESCRIPTION
Missing comma separating throw attributes cause an error on Railo servers
