### PR TITLE
CF11 Breaks due to syntax error

### DIFF
--- a/system/core/result/ValidationMessageProvider.cfc
+++ b/system/core/result/ValidationMessageProvider.cfc
@@ -46,7 +46,7 @@ component accessors="true" {
 		
 		// if you are here we couldn't find a message 
 		throw(
-			type="ValidationMessage"
+			type="ValidationMessage",
 			message="There is no message defined for type '#lcase(type)#'"
 		);
 		


### PR DESCRIPTION
Missing a comma in

```
        throw(
            type="ValidationMessage", //<---- This comma
            message="There is no message defined for type '#lcase(type)#'"
        );
```
